### PR TITLE
Adds loadstate tracking to frame

### DIFF
--- a/lib/playwright/frame.ex
+++ b/lib/playwright/frame.ex
@@ -1,12 +1,12 @@
 defmodule Playwright.Frame do
   @moduledoc false
-  use Playwright.Runner.ChannelOwner, fields: [:url]
+  use Playwright.Runner.ChannelOwner, fields: [:url, :loadstate]
   alias Playwright.Runner.Channel
   alias Playwright.Runner.ChannelOwner
 
   @impl ChannelOwner
   def new(%{connection: _connection} = parent, args) do
-    init(parent, args)
+    Map.merge(init(parent, args), %{loadstate: []})
   end
 
   # callbacks
@@ -17,10 +17,32 @@ defmodule Playwright.Frame do
     {:ok, Map.put(subject, :url, event.params.url)}
   end
 
+  @impl ChannelOwner
+  def before_event(subject, %Channel.Event{type: :loadstate} = event) do
+    method = if Map.has_key?(event.params, :add) do
+      :add
+    else
+      :remove
+    end
+
+    loadstate = Map.get(subject, :loadstate, [])
+    case method do
+      :add ->
+        {:ok, Map.put(subject, :loadstate, [event.params.add | loadstate])}
+      :remove ->
+        {:ok, Map.put(subject, :loadstate, Enum.filter(loadstate, fn state -> state != event.params.remove end))}
+    end
+  end
+
   # API
   # ---------------------------------------------------------------------------
 
   def url(f) do
     f.url
+  end
+
+  def on(subject, event, handler) do
+    Channel.on(subject.connection, {event, subject}, handler)
+    subject
   end
 end

--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -155,6 +155,16 @@ defmodule Playwright.Page do
     subject
   end
 
+  def on(subject, event, handler)
+      when event in ["loadstate"] do
+    # NOTE: the event/method will be recv'd from Playwright server with
+    # the Frame as the context/bound :guid. So, we need to
+    # add our handlers there, on that (BrowserContext) parent.
+    parent = Channel.get(subject.connection, {:guid, frame(subject).guid})
+    Channel.on(subject.connection, {event, parent}, handler)
+    subject
+  end
+
   require Logger
 
   def on(subject, event, handler) do


### PR DESCRIPTION
Allows for listening to loadstate changes on the page to wait for things like `networkidle`, `domcontentloaded` and `load` etc.

```elixir
page |> Playwright.Page.on("loadstate", fn frame, event ->
  if Enum.member?(frame.loadstate, "networkidle") do
     # Network Idle
  end
end)
```

Also adds response to the `requestFinished` event.