### PR TITLE
Hotfix/large responses

### DIFF
--- a/lib/playwright/runner/transport/driver_message.ex
+++ b/lib/playwright/runner/transport/driver_message.ex
@@ -36,7 +36,7 @@ defmodule Playwright.Runner.Transport.DriverMessage do
           frames: list(),
           remaining: number()
         }
-  def parse(<<head::little-integer-size(32)>>, 0, "", accumulated) do
+  def parse(<<head::unsigned-little-integer-size(32)>>, 0, "", accumulated) do
     %{
       buffer: "",
       frames: accumulated,
@@ -44,7 +44,7 @@ defmodule Playwright.Runner.Transport.DriverMessage do
     }
   end
 
-  def parse(<<head::little-integer-size(32), data::binary>>, 0, "", accumulated) do
+  def parse(<<head::unsigned-little-integer-size(32), data::binary>>, 0, "", accumulated) do
     parse(data, head, "", accumulated)
   end
 

--- a/lib/playwright/runner/transport/driver_message.ex
+++ b/lib/playwright/runner/transport/driver_message.ex
@@ -36,7 +36,7 @@ defmodule Playwright.Runner.Transport.DriverMessage do
           frames: list(),
           remaining: number()
         }
-  def parse(<<head::utf32-little>>, 0, "", accumulated) do
+  def parse(<<head::little-integer-size(32)>>, 0, "", accumulated) do
     %{
       buffer: "",
       frames: accumulated,
@@ -44,7 +44,7 @@ defmodule Playwright.Runner.Transport.DriverMessage do
     }
   end
 
-  def parse(<<head::utf32-little, data::binary>>, 0, "", accumulated) do
+  def parse(<<head::little-integer-size(32), data::binary>>, 0, "", accumulated) do
     parse(data, head, "", accumulated)
   end
 


### PR DESCRIPTION
There is an issue where this library hangs on large response body parsing. It seems that the utf encoding doesn't match correctly and causes issues (I'm not sure how encoding differ). Simply changing it to a 32 bit little endian unsigned integer which fixes this issue.