### PR TITLE
Feature/customize playwright cli path

### DIFF
--- a/lib/playwright/browser_type.ex
+++ b/lib/playwright/browser_type.ex
@@ -41,7 +41,7 @@ defmodule Playwright.BrowserType do
   @doc """
   Launch a new local browser.
   """
-  @spec launch(any) :: {pid, Playwright.Browser.t()}
+  @spec launch(any) :: {pid(), Playwright.Browser.t()}
   def launch(cli_path \\ nil) do
     {:ok, connection} = new_session(Transport.Driver, [cli_path || "assets/node_modules/playwright/cli.js"])
     {connection, chromium(connection)}

--- a/lib/playwright/browser_type.ex
+++ b/lib/playwright/browser_type.ex
@@ -41,7 +41,7 @@ defmodule Playwright.BrowserType do
   @doc """
   Launch a new local browser.
   """
-  @spec launch(any) :: {pid(), Playwright.Browser.t()}
+  @spec launch(String.t() | nil) :: {pid(), Playwright.Browser.t()}
   def launch(cli_path \\ nil) do
     {:ok, connection} = new_session(Transport.Driver, [cli_path || "assets/node_modules/playwright/cli.js"])
     {connection, chromium(connection)}

--- a/lib/playwright/browser_type.ex
+++ b/lib/playwright/browser_type.ex
@@ -41,9 +41,9 @@ defmodule Playwright.BrowserType do
   @doc """
   Launch a new local browser.
   """
-  @spec launch() :: {pid(), Playwright.Browser.t()}
-  def launch do
-    {:ok, connection} = new_session(Transport.Driver, ["assets/node_modules/playwright/cli.js"])
+  @spec launch(any) :: {pid, Playwright.Browser.t()}
+  def launch(cli_path \\ nil) do
+    {:ok, connection} = new_session(Transport.Driver, [cli_path || "assets/node_modules/playwright/cli.js"])
     {connection, chromium(connection)}
   end
 

--- a/lib/playwright/runner/config.ex
+++ b/lib/playwright/runner/config.ex
@@ -147,6 +147,23 @@ defmodule Playwright.Runner.Config do
       config :playwright, LaunchOptions,
         executable_path: "/Applications/..."
 
+  ### `playwright_cli_path` (optional)
+
+  A filesystem path to the playwright cli.js file to use instead of the default
+  assets path.
+
+  **Chromium-only**
+
+  This can be helpful for packaged releases or systems where the node_module may
+  be located elsewhere on the filesystem.
+
+  **Use `playwright_cli_path` option with extreme caution.**
+
+  e.g.,
+
+      config :playwright, ConnectOptions,
+        playwright_cli_path: "/Cache/.../playwright/cli.js"
+
   ## Details for `PlaywrightTest`
 
   Configuration for usage of `PlaywrightTest.Case`.
@@ -172,7 +189,8 @@ defmodule Playwright.Runner.Config do
 
   @typedoc false
   @type connect_options :: %{
-          ws_endpoint: String.t()
+          ws_endpoint: String.t(),
+          playwright_cli_path: String.t(),
         }
 
   @typedoc false
@@ -197,7 +215,7 @@ defmodule Playwright.Runner.Config do
 
     defmodule ConnectOptions do
       @moduledoc false
-      defstruct [:ws_endpoint]
+      defstruct [:ws_endpoint, :playwright_cli_path]
     end
 
     defmodule LaunchOptions do
@@ -212,10 +230,9 @@ defmodule Playwright.Runner.Config do
   end
 
   @doc false
-  @spec connect_options(boolean()) :: Types.ConnectOptions
+  @spec connect_options(boolean()) :: connect_options
   def connect_options(camelcase \\ false) do
     config_for(ConnectOptions, %Types.ConnectOptions{}, camelcase) || %{}
-    # |> clean()
   end
 
   @doc false

--- a/lib/playwright_test/case.ex
+++ b/lib/playwright_test/case.ex
@@ -82,7 +82,8 @@ defmodule PlaywrightTest.Case do
       defp setup_browser(runner_options) do
         case runner_options.transport do
           :driver ->
-            Playwright.BrowserType.launch()
+            options = Config.connect_options()
+            Playwright.BrowserType.launch(Map.get(options, :playwright_cli_path))
 
           :websocket ->
             options = Config.connect_options()


### PR DESCRIPTION
In some scenarios its useful to be able to customize the executable location of playwright's cli.js.