### PR TITLE
Adds default playwright_cli_path to ./assets/node_modules/playwright/cli.js

### DIFF
--- a/lib/playwright/runner/config.ex
+++ b/lib/playwright/runner/config.ex
@@ -228,7 +228,7 @@ defmodule Playwright.Runner.Config do
         :downloads_path,
         :executable_path,
         :headless,
-        playwright_cli_path: "#{__DIR__}/../../../assets/node_modules/playwright/cli.js"
+        :playwright_cli_path
       ]
     end
 

--- a/lib/playwright/runner/config.ex
+++ b/lib/playwright/runner/config.ex
@@ -228,7 +228,7 @@ defmodule Playwright.Runner.Config do
         :downloads_path,
         :executable_path,
         :headless,
-        :playwright_cli_path
+        playwright_cli_path: "#{__DIR__}/../../../assets/node_modules/playwright/cli.js"
       ]
     end
 

--- a/lib/playwright/runner/transport/driver.ex
+++ b/lib/playwright/runner/transport/driver.ex
@@ -22,7 +22,7 @@ defmodule Playwright.Runner.Transport.Driver do
 
   @impl GenServer
   def init({connection, config}) do
-    cli = config.playwright_cli_path
+    cli = Map.get(config, :playwright_cli_path, "#{__DIR__}/../../../../assets/node_modules/playwright/cli.js")
     cmd = "run-driver"
 
     port = Port.open({:spawn, "#{cli} #{cmd}"}, [:binary, :exit_status])

--- a/lib/playwright/runner/transport/driver.ex
+++ b/lib/playwright/runner/transport/driver.ex
@@ -22,7 +22,7 @@ defmodule Playwright.Runner.Transport.Driver do
 
   @impl GenServer
   def init({connection, config}) do
-    cli = Map.get(config, :playwright_cli_path, "#{__DIR__}/../../../../assets/node_modules/playwright/cli.js")
+    cli = Map.get(config, :playwright_cli_path, Path.join(:code.priv_dir(:playwright), "static/playwright_cli.js"))
     cmd = "run-driver"
 
     port = Port.open({:spawn, "#{cli} #{cmd}"}, [:binary, :exit_status])


### PR DESCRIPTION
Seems like the default repo breaks when trying to create a browser without special configurations.
This sets a default so chromium can find the cli.js file without any configuration needed.