### PR TITLE
Adds Browser.close()/1

### DIFF
--- a/lib/playwright/browser.ex
+++ b/lib/playwright/browser.ex
@@ -147,6 +147,13 @@ defmodule Playwright.Browser do
     Channel.patch(connection, page.guid, %{owned_context: context})
   end
 
+  @doc """
+  Closes the browser. Careful as all pages and contexts are closed and now invalid.
+  """
+  def close(browser) do
+    Channel.post(browser, :close, %{})
+  end
+
   # ---
 
   # test_browsertype_connect.py


### PR DESCRIPTION
Allows for closing the whole browser, not just a page using `Brower.close()/1`