### PR TITLE
Feature/api request context

### DIFF
--- a/lib/playwright/api_request_context.ex
+++ b/lib/playwright/api_request_context.ex
@@ -23,7 +23,7 @@ defmodule Playwright.APIRequestContext do
     optional(:ignoreHTTPSErrors) => boolean()
   }
 
-  @spec post(t(), binary(), fetch_options()) :: t()
+  @spec post(t(), binary(), fetch_options()) :: Playwright.APIResponse.t()
   def post(%APIRequestContext{} = request_context, url, options \\ %{}) do
     Channel.post(request_context, :fetch, Map.merge(%{
       url: url,
@@ -31,6 +31,7 @@ defmodule Playwright.APIRequestContext do
     }, options))
   end
 
+  @spec body(t(), Playwright.APIResponse.t()) :: any()
   def body(%APIRequestContext{} = request_context, response) do
     Channel.post(request_context, :fetch_response_body, %{
       fetchUid: response.fetchUid

--- a/lib/playwright/api_request_context.ex
+++ b/lib/playwright/api_request_context.ex
@@ -1,5 +1,11 @@
 defmodule Playwright.APIRequestContext do
-  @moduledoc false
+  @moduledoc """
+  This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services,
+  prepare environment or the server to your e2e test.
+
+  Use this at caution as has not been tested.
+
+  """
 
   use Playwright.ChannelOwner
   alias Playwright.APIRequestContext

--- a/lib/playwright/api_request_context.ex
+++ b/lib/playwright/api_request_context.ex
@@ -1,4 +1,33 @@
 defmodule Playwright.APIRequestContext do
   @moduledoc false
+
   use Playwright.ChannelOwner
+  alias Playwright.APIRequestContext
+
+  @type fetch_options() :: %{
+    optional(:params) => any(),
+    optional(:method) => binary(),
+    optional(:headers) => any(),
+    optional(:postData) => any(),
+    optional(:jsonData) => any(),
+    optional(:formData) => any(),
+    optional(:multipartData) => any(),
+    optional(:timeout) => non_neg_integer(),
+    optional(:failOnStatusCode) => boolean(),
+    optional(:ignoreHTTPSErrors) => boolean()
+  }
+
+  @spec post(t(), binary(), fetch_options()) :: t()
+  def post(%APIRequestContext{} = request_context, url, options \\ %{}) do
+    Channel.post(request_context, :fetch, Map.merge(%{
+      url: url,
+      method: "POST"
+    }, options))
+  end
+
+  def body(%APIRequestContext{} = request_context, response) do
+    Channel.post(request_context, :fetch_response_body, %{
+      fetchUid: response.fetchUid
+    })
+  end
 end

--- a/lib/playwright/api_response.ex
+++ b/lib/playwright/api_response.ex
@@ -1,4 +1,16 @@
 defmodule Playwright.APIResponse do
   @moduledoc false
   use Playwright.ChannelOwner
+  alias Playwright.APIResponse
+
+  @property :fetchUid
+  @property :headers
+  @property :status
+  @property :status_text
+  @property :url
+
+  @spec ok(t()) :: boolean()
+  def ok(%APIResponse{} = response) do
+    response.status === 0 || (response.status >= 200 && response.status <= 299)
+  end
 end

--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -349,11 +349,9 @@ defmodule Playwright.Page do
   # ---
 
   @spec request(t()) :: Playwright.APIRequestContext.t()
-  def request(%Page{} = page) do
-    List.first(Channel.all(page.connection, %{
-      parent: page.owned_context.browser,
-      type: "APIRequestContext"
-    }))
+  def request(%Page{session: session} = page) do
+    Channel.list(session, {:guid, page.owned_context.browser.guid}, "APIRequestContext")
+    |> List.first()
   end
 
   # NOTE: these events will be recv'd from Playwright server with

--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -346,6 +346,16 @@ defmodule Playwright.Page do
     Playwright.Locator.new(page, selector)
   end
 
+  # ---
+
+  @spec request(t()) :: Playwright.APIRequestContext.t()
+  def request(%Page{} = page) do
+    List.first(Channel.all(page.connection, %{
+      parent: page.owned_context.browser,
+      type: "APIRequestContext"
+    }))
+  end
+
   # NOTE: these events will be recv'd from Playwright server with
   # the parent BrowserContext as the context/bound :guid. So, we need to
   # add our handlers there, on that (BrowserContext) parent.

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule Playwright.MixProject do
       groups_for_modules: [
         "Capabilities (API)": [
           Playwright,
+          Playwright.APIRequestContext,
           Playwright.Browser,
           Playwright.BrowserContext,
           Playwright.BrowserType,


### PR DESCRIPTION
This explore adding initial [APIRequestContext](https://playwright.dev/docs/api/class-apirequestcontext#api-request-context-post) api to this library. Currently only `APIRequestContext.post/1` and `Page.request/1`.

This allows for sending API requests from within the context.

Currently not exhaustive API, does not have a test suite and is not verified to match the main playwright implementation exactly.