### PR TITLE
implementing Page.expose_function/3

### DIFF
--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -270,10 +270,12 @@ defmodule Playwright.Page do
   # @spec expose_binding(t(), binary(), function(), options()) :: :ok
   # def expose_binding(page, name, callback, options \\ %{})
 
-  # @spec expose_function(t(), binary(), function()) :: :ok
-  # def expose_function(page, name, callback)
-
   # ---
+
+  @spec expose_function(t(), binary(), function()) :: :ok
+  def expose_function(%Page{} = page, name, callback) do
+    context(page) |> BrowserContext.expose_function(name, callback)
+  end
 
   @spec fill(t(), binary(), binary(), options()) :: :ok
   def fill(%Page{} = page, selector, value, options \\ %{}) do

--- a/test/integration/page_test.exs
+++ b/test/integration/page_test.exs
@@ -315,6 +315,17 @@ defmodule Playwright.PageTest do
     end
   end
 
+  describe "Page.expose_function/3" do
+    test "binds a local function", %{page: page} do
+      handler = fn [a, b] ->
+        a * b
+      end
+
+      Page.expose_function(page, "add", handler)
+      assert Page.evaluate(page, "add(9, 4)") == 36
+    end
+  end
+
   describe "Page.fill/3" do
     test "sets text content", %{assets: assets, page: page} do
       page


### PR DESCRIPTION
Simple implementation of `Page.expose_function/3` leveraging `BrowserContext.expose_function/3` implementation