### PR TITLE
[DOCS] Fix link to Readme on hex.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ end
 
 ## Usage
 
-- [README](https://hexdocs.pm/playwright/README.html)
+- [README](https://hexdocs.pm/playwright/readme.html)
 - [Getting started](https://hexdocs.pm/playwright/basics-getting-started.html)
 - [API Reference](https://hexdocs.pm/playwright/api-reference.html)
 


### PR DESCRIPTION
URLs on hex.pm are case sensitive. This fixes the link to the rendered Readme.