### PR TITLE
Support page content

### DIFF
--- a/lib/playwright/frame.ex
+++ b/lib/playwright/frame.ex
@@ -127,8 +127,16 @@ defmodule Playwright.Frame do
 
   # ---
 
-  # @spec content(Frame.t()) :: binary()
-  # def content(frame)
+  @spec content(Frame.t()) :: binary() | {:error, term()}
+  def content(%Frame{session: session} = frame) do
+    case Channel.post(session, {:guid, frame.guid}, :content) do
+      {:error, error} ->
+        {:error, error}
+
+      content ->
+        content
+    end
+  end
 
   # ---
 

--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -243,6 +243,11 @@ defmodule Playwright.Page do
     Channel.find(session, {:guid, page.parent.guid})
   end
 
+  @spec content(t()) :: binary()
+  def content(%Page{} = page) do
+    main_frame(page) |> Frame.content()
+  end
+
   @doc """
   A shortcut for the main frame's `Playwright.Frame.dblclick/3`.
   """

--- a/lib/playwright/page.ex
+++ b/lib/playwright/page.ex
@@ -243,7 +243,7 @@ defmodule Playwright.Page do
     Channel.find(session, {:guid, page.parent.guid})
   end
 
-  @spec content(t()) :: binary()
+  @spec content(t()) :: binary() | {:error, term()}
   def content(%Page{} = page) do
     main_frame(page) |> Frame.content()
   end

--- a/test/api/page_test.exs
+++ b/test/api/page_test.exs
@@ -450,6 +450,16 @@ defmodule Playwright.PageTest do
     end
   end
 
+  describe "Page.content/0" do
+    test "retrieves the page content", %{assets: assets, page: page} do
+      page
+      |> Page.goto(assets.prefix <> "/dom.html")
+
+      assert Page.content(page) =~
+               ~r/<html>/
+    end
+  end
+
   describe "Page.title/1" do
     test "retrieves the title text", %{assets: assets, page: page} do
       page

--- a/test/api/page_test.exs
+++ b/test/api/page_test.exs
@@ -441,7 +441,7 @@ defmodule Playwright.PageTest do
     end
   end
 
-  describe "Page.test_content/2" do
+  describe "Page.text_content/2" do
     test "retrieves content", %{assets: assets, page: page} do
       page
       |> Page.goto(assets.prefix <> "/dom.html")


### PR DESCRIPTION
Playwright provides a `.content()` function allowing retrieval of the a page's HTML. https://playwright.dev/docs/api/class-frame#frame-content

This was missing in `playwright-elixir`, but looks like there was some intent to support it as there was commented out code in `frame.ex`.

I've added the implementation and a test.