### PR TITLE
Examples of setting user-agent

### DIFF
--- a/man/guides/browsers.md
+++ b/man/guides/browsers.md
@@ -1,3 +1,24 @@
 # Browsers
 
-...
+## Setting a custom user agent
+
+It's possible to set the user agent to a custom value via `BrowserContext` or `Browser`
+### With Browser
+
+```elixir
+page = Playwright.Browser.new_page(browser, %{"userAgent" => "My Custom Agent"})
+```
+
+### With BrowserContext
+
+```elixir
+context = Browser.new_context(browser, %{"userAgent" => "Special Agent"})
+```
+
+## Custom Agent and Phoenix / Ecto
+
+Setting a custom agent can be particularly useful when running Playwright in tests with the database involved.
+
+Follow https://hexdocs.pm/phoenix_ecto/Phoenix.Ecto.SQL.Sandbox.html and set the `userAgent` to the result of `Phoenix.Ecto.SQL.Sandbox.metadata_for(YourApp.Repo, pid)`
+
+

--- a/test/api/browser_context_test.exs
+++ b/test/api/browser_context_test.exs
@@ -273,11 +273,21 @@ defmodule Playwright.BrowserContextTest do
   end
 
   describe "User Agent" do
-    test "should work", %{browser: browser} do
+    test "can be set via new_context", %{browser: browser} do
       context = Browser.new_context(browser, %{"userAgent" => "Mozzies"})
       page = BrowserContext.new_page(context)
 
       assert Page.evaluate(page, "window.navigator.userAgent") == "Mozzies"
+
+      BrowserContext.close(context)
+    end
+
+    test "can be set via new_page", %{browser: browser} do
+      page = Browser.new_page(browser, %{"userAgent" => "Mozzies"})
+
+      assert Page.evaluate(page, "window.navigator.userAgent") == "Mozzies"
+
+      Page.close(page)
     end
   end
 end

--- a/test/api/browser_context_test.exs
+++ b/test/api/browser_context_test.exs
@@ -271,6 +271,15 @@ defmodule Playwright.BrowserContextTest do
       assert Page.evaluate(page, "window.navigator.onLine")
     end
   end
+
+  describe "User Agent" do
+    test "should work", %{browser: browser} do
+      context = Browser.new_context(browser, %{"userAgent" => "Mozzies"})
+      page = BrowserContext.new_page(context)
+
+      assert Page.evaluate(page, "window.navigator.userAgent") == "Mozzies"
+    end
+  end
 end
 
 # test_expose_function_should_throw_for_duplicate_registrations


### PR DESCRIPTION
Adds a test and some documentation so show setting a custom user agent.

This will be important for users if they want to run Playwright for integration testing with Phoenix/Ecto