### PR TITLE
Handle more websocket responses for phoenix_test

### DIFF
--- a/lib/playwright/sdk/channel/response.ex
+++ b/lib/playwright/sdk/channel/response.ex
@@ -93,6 +93,18 @@ defmodule Playwright.SDK.Channel.Response do
     values
   end
 
+  defp parse([{:matches, matches}], _catalog) do
+    matches
+  end
+
+  defp parse([{:matches, matches}, {:received, _}], _catalog) do
+    matches
+  end
+
+  defp parse([{:log, _}, {:matches, matches}, {:received, _}, {:timedOut, true}], _catalog) do
+    matches
+  end
+
   defp parse([], _catalog) do
     nil
   end


### PR DESCRIPTION
In my WIP attempt to use this library to add a Playwright driver to `phoenix_test` I have to handle a few extra websocket response types.

germsvel/phoenix_test/pull/136

These are the three additional ones. If helpful, I can dig up when/why I needed them exactly.

It would be helpful if `playwright-elixir` either supported them or offered an extension mechanism instead of failing on unknown response types.