### PR TITLE
Replace no-longer-live playwright link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-[Playwright](https://github.com/mechanical-orchard/playwright-elixir) is an Elixir library to automate Chromium, Firefox and WebKit with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**. [See how Playwright is better](https://playwright.dev/docs/why-playwright).
+[Playwright](https://github.com/mechanical-orchard/playwright-elixir) is an Elixir library to automate Chromium, Firefox and WebKit with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**. [See how Playwright is better](https://playwright.dev/).
 
 ## Installation
 


### PR DESCRIPTION
- the previously-linked 'https://playwright.dev/docs/why-playwright' page is no longer hosted, nor does it seem to have an obvious replacement. That said, the playwright.dev homepage outlines a lot of the benefits of playwright, so it's an improvement over the current deadlink